### PR TITLE
[CM-87] Vercel 배포 시 전체 프로젝트 목록의 무한 로딩 문제 해결

### DIFF
--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -4,54 +4,11 @@ import LoadingCheckMate from '@/components/LoadingCheckMate'
 import { ProjectFilter, ProjectList } from '@/components/project/home'
 import { useAuthStore } from '@/stores/useAuthStore'
 import { Project } from '@/types/project'
+import { signOut } from 'next-auth/react'
 import { useEffect, useState } from 'react'
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL
-
-const mockProjects: Project[] = [
-  {
-    projectId: 'mock-1',
-    projectTitle: 'Mock Project 1',
-    projectImageUrl: '/images/mock1.png',
-    profile: {
-      stacks: ['React', 'Node.js'],
-      positions: ['Frontend', 'Backend'],
-      projectId: 'mock-1',
-    },
-    startDate: '2025-01-01',
-    endDate: '2025-06-30',
-    members: [],
-    leader: {
-      name: 'Mock Leader',
-      email: 'leader@example.com',
-      profileImageUrl: '/images/leader.png',
-      profiles: [],
-      role: 'Leader',
-      pendingProjectIds: [],
-    },
-  },
-  {
-    projectId: 'mock-2',
-    projectTitle: 'Mock Project 2',
-    projectImageUrl: '/images/mock2.png',
-    profile: {
-      stacks: ['Next.js', 'Django'],
-      positions: ['Fullstack'],
-      projectId: 'mock-2',
-    },
-    startDate: '2025-02-01',
-    endDate: '2025-07-31',
-    members: [],
-    leader: {
-      name: 'Mock Leader 2',
-      email: 'leader2@example.com',
-      profileImageUrl: '/images/leader2.png',
-      profiles: [],
-      role: 'Leader',
-      pendingProjectIds: [],
-    },
-  },
-]
+const LOADING_TIMEOUT = 10000
 
 const Home = () => {
   const user = useAuthStore((state) => state.user)
@@ -63,6 +20,13 @@ const Home = () => {
     if (!user?.accessToken) {
       return
     }
+
+    const loadingTimeout = setTimeout(() => {
+      if (loading) {
+        console.error('응답이 지연되고 있어 로그인 페이지로 이동합니다.')
+        signOut({ callbackUrl: '/login' })
+      }
+    }, LOADING_TIMEOUT)
 
     const fetchProjects = async () => {
       try {
@@ -80,21 +44,21 @@ const Home = () => {
 
         const data: Project[] = await response.json()
 
-        if (data.length === 0) {
-          setProjects(mockProjects)
-        } else {
-          setProjects(data)
-        }
+        setProjects(data)
       } catch (error) {
         console.error(error)
-        setProjects(mockProjects)
       } finally {
         setLoading(false)
+        clearTimeout(loadingTimeout)
       }
     }
 
     fetchProjects()
-  }, [filter, user?.accessToken])
+
+    return () => {
+      clearTimeout(loadingTimeout)
+    }
+  }, [filter, user?.accessToken, loading])
 
   return (
     <>

--- a/stores/useAuthStore.ts
+++ b/stores/useAuthStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
 
 type User = {
   name: string
@@ -13,8 +14,15 @@ type AuthStore = {
   clearUser: () => void
 }
 
-export const useAuthStore = create<AuthStore>((set) => ({
-  user: null,
-  setUser: (user) => set({ user }),
-  clearUser: () => set({ user: null }),
-}))
+export const useAuthStore = create<AuthStore>()(
+  persist(
+    (set) => ({
+      user: null,
+      setUser: (user) => set({ user }),
+      clearUser: () => set({ user: null }),
+    }),
+    {
+      name: 'auth-storage',
+    }
+  )
+)


### PR DESCRIPTION
## 🔗 Jira Ticket

- 관련 지라 티켓: [CM-87](https://starmix.atlassian.net/browse/CM-87)

## 📌 PR Type
- [X] ✨ Feature
- [X] 🐛 Bugfix

## 📝 작업 내용

- 사용자 정보 저장 시 persist를 사용하도록 개선
- 프로젝트 목록 조회 timeout 시에 로그아웃이 되도록 개선
