### PR TITLE
[CM-166] Epic 페이지 Sprint 별 필터링 기능 구현

### DIFF
--- a/apps/web/app/projects/[id]/(isActive)/epic/page.tsx
+++ b/apps/web/app/projects/[id]/(isActive)/epic/page.tsx
@@ -29,19 +29,12 @@ import { useEffect, useRef, useState } from 'react'
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL
 
-// 가짜 스프린트 데이터
-const MOCK_SPRINTS = [
-  { id: '1', name: 'Sprint 1' },
-  { id: '2', name: 'Sprint 2' },
-  { id: '3', name: 'Sprint 3' },
-  { id: '4', name: 'Sprint 4' },
-]
-
 export default function ProjectEpic() {
   const { id } = useParams()
   const [loading, setLoading] = useState(true)
   const [project, setProject] = useState<Project | null>(null)
   const [epics, setEpics] = useState<Epic[]>([])
+  const [filteredEpics, setFilteredEpics] = useState<Epic[]>([])
   const [isCreateEpicDialogOpen, setIsCreateEpicDialogOpen] = useState(false)
   const [isDeleteEpicDialogOpen, setIsDeleteEpicDialogOpen] = useState(false)
   const [isSprintDropdownOpen, setIsSprintDropdownOpen] = useState(false)
@@ -49,14 +42,26 @@ export default function ProjectEpic() {
   const user = useAuthStore((state) => state.user)
 
   const [viewMode, setViewMode] = useState<ViewMode>(ViewMode.Week)
-  const [viewType, setViewType] = useState<'WEEK' | 'SPRINT'>('WEEK')
+  const [viewType, setViewType] = useState<'EPIC' | 'SPRINT'>('EPIC')
   const [selectedSprint, setSelectedSprint] = useState<string | null>(null)
+  const [sprints, setSprints] = useState<
+    {
+      sprintId: string
+      title: string
+      description: string
+      sequence: number
+      projectId: string
+      startDate: string
+      endDate: string
+    }[]
+  >([])
 
   useEffect(() => {
     if (!user?.accessToken || !id) return
 
     const fetchProjectDetails = async () => {
       try {
+        setLoading(true)
         // 프로젝트 상세 정보 가져오기
         const projectResponse = await fetch(`${API_BASE_URL}/project/${id}`, {
           headers: {
@@ -88,7 +93,18 @@ export default function ProjectEpic() {
         }
 
         const epicsData = await epicsResponse.json()
-        setEpics(epicsData)
+        // API 응답을 Epic 타입에 맞게 변환
+        const transformedEpics = epicsData.map((epic: any) => ({
+          epicId: epic.epicId,
+          title: epic.title,
+          description: epic.description,
+          startDate: epic.startDate || new Date().toISOString(),
+          endDate: epic.endDate || new Date().toISOString(),
+          sprint: epic.sprint || null,
+          tasks: epic.tasks || [],
+        }))
+        setEpics(transformedEpics)
+        setFilteredEpics(transformedEpics)
       } catch (error) {
         console.error(error)
       } finally {
@@ -98,6 +114,44 @@ export default function ProjectEpic() {
 
     fetchProjectDetails()
   }, [id, user?.accessToken])
+
+  // 스프린트 목록 가져오기
+  useEffect(() => {
+    if (!user?.accessToken || !id) return
+
+    const fetchSprints = async () => {
+      try {
+        const response = await fetch(`${API_BASE_URL}/sprint?projectId=${id}`, {
+          headers: {
+            Accept: '*/*',
+            Authorization: `Bearer ${user?.accessToken}`,
+          },
+        })
+
+        if (!response.ok) {
+          throw new Error('스프린트 목록 불러오기 실패')
+        }
+
+        const sprintsData = await response.json()
+        setSprints(sprintsData)
+      } catch (error) {
+        console.error(error)
+      }
+    }
+
+    fetchSprints()
+  }, [id, user?.accessToken])
+
+  // 선택된 스프린트가 변경될 때 에픽 목록 필터링
+  useEffect(() => {
+    if (!epics.length) return
+
+    const filtered = selectedSprint
+      ? epics.filter((epic) => epic.sprint?.sprintId === selectedSprint)
+      : epics
+
+    setFilteredEpics(filtered)
+  }, [selectedSprint, epics])
 
   // 드롭다운 외부 클릭 시 닫기
   useEffect(() => {
@@ -153,16 +207,16 @@ export default function ProjectEpic() {
           <div className="flex gap-2 items-center">
             <button
               className={`text-base font-medium mr-2 px-2 py-3.5 border-b-2 transition ${
-                viewMode === ViewMode.Week && viewType === 'WEEK'
+                viewMode === ViewMode.Week && viewType === 'EPIC'
                   ? 'text-cm-900 border-cm-900'
                   : 'text-cm-100 border-transparent'
               }`}
               onClick={() => {
                 setViewMode(ViewMode.Week)
-                setViewType('WEEK')
+                setViewType('EPIC')
               }}
             >
-              Week
+              Epic
             </button>
             <button
               className={`text-base font-medium px-2 py-3.5 border-b-2 transition ${
@@ -172,7 +226,7 @@ export default function ProjectEpic() {
               }`}
               onClick={() => {
                 setViewMode(ViewMode.Day)
-                setViewType('WEEK')
+                setViewType('EPIC')
               }}
             >
               Day
@@ -199,16 +253,26 @@ export default function ProjectEpic() {
                     </button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="start">
-                    {MOCK_SPRINTS.map((sprint) => (
+                    <DropdownMenuItem
+                      onClick={() => {
+                        setSelectedSprint(null)
+                        setViewMode(ViewMode.Week)
+                        setViewType('SPRINT')
+                      }}
+                      className="text-cm hover:text-cm-900"
+                    >
+                      ALL
+                    </DropdownMenuItem>
+                    {sprints.map((sprint) => (
                       <DropdownMenuItem
-                        key={sprint.id}
+                        key={sprint.sprintId}
                         onClick={() => {
-                          setSelectedSprint(sprint.id)
+                          setSelectedSprint(sprint.sprintId)
                           setViewMode(ViewMode.Week)
                           setViewType('SPRINT')
                         }}
                       >
-                        {sprint.name}
+                        {sprint.title}
                       </DropdownMenuItem>
                     ))}
                   </DropdownMenuContent>
@@ -233,12 +297,12 @@ export default function ProjectEpic() {
           </div>
         </div>
 
-        <div className="bg-white p-6 w-full overflow-x-auto overflow-y-hidden whitespace-nowrap transform-gpu">
+        <div className="mt-4">
           {loading ? (
             <Skeleton className="h-[600px] w-full" />
           ) : (
             <Gantt
-              epics={epics}
+              epics={filteredEpics}
               viewMode={viewMode}
               columnWidth={viewMode === ViewMode.Day ? 40 : 60}
             />

--- a/apps/web/app/projects/[id]/(isActive)/epic/page.tsx
+++ b/apps/web/app/projects/[id]/(isActive)/epic/page.tsx
@@ -178,7 +178,11 @@ export default function ProjectEpic() {
           {loading ? (
             <Skeleton className="h-[600px] w-full" />
           ) : (
-            <Gantt epics={epics} viewMode={viewMode} />
+            <Gantt
+              epics={epics}
+              viewMode={viewMode}
+              columnWidth={viewMode === ViewMode.Day ? 40 : 60}
+            />
           )}
         </div>
 

--- a/apps/web/app/projects/[id]/(isActive)/epic/page.tsx
+++ b/apps/web/app/projects/[id]/(isActive)/epic/page.tsx
@@ -174,7 +174,7 @@ export default function ProjectEpic() {
           </div>
         </div>
 
-        <div className="bg-white p-6 max-w-full overflow-scroll">
+        <div className="bg-white p-6 w-full overflow-x-auto overflow-y-hidden whitespace-nowrap transform-gpu">
           {loading ? (
             <Skeleton className="h-[600px] w-full" />
           ) : (

--- a/apps/web/components/project/epic/calendar/calendar.tsx
+++ b/apps/web/components/project/epic/calendar/calendar.tsx
@@ -183,9 +183,10 @@ export const Calendar: React.FC<CalendarProps> = ({
       bottomValues.push(
         <text
           key={date.getTime()}
-          y={headerHeight * 0.8}
+          y={headerHeight * 0.5 + headerHeight * 0.25}
           x={columnWidth * (i + +rtl) + columnWidth * 0.5}
           className={styles.calendarBottomText}
+          dominantBaseline="middle"
         >
           {bottomValue}
         </text>
@@ -220,16 +221,15 @@ export const Calendar: React.FC<CalendarProps> = ({
     const dates = dateSetup.dates
     for (let i = 0; i < dates.length; i++) {
       const date = dates[i]
-      const bottomValue = `${getLocalDayOfWeek(date, locale, 'short')}, ${date
-        .getDate()
-        .toString()}`
+      const bottomValue = date.getDate().toString()
 
       bottomValues.push(
         <text
           key={date.getTime()}
-          y={headerHeight * 0.8}
+          y={headerHeight * 0.5 + headerHeight * 0.25}
           x={columnWidth * i + columnWidth * 0.5}
           className={styles.calendarBottomText}
+          dominantBaseline="middle"
         >
           {bottomValue}
         </text>

--- a/apps/web/components/project/epic/gantt/gantt.module.css
+++ b/apps/web/components/project/epic/gantt/gantt.module.css
@@ -35,3 +35,22 @@
   display: block;
   position: relative;
 }
+
+.gantt {
+  display: flex;
+  overflow: hidden;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  transform: translateZ(0);
+  backface-visibility: hidden;
+  perspective: 1000px;
+}
+
+.gantt-content {
+  position: relative;
+  overflow: auto;
+  transform: translateZ(0);
+  backface-visibility: hidden;
+  perspective: 1000px;
+}

--- a/apps/web/components/project/epic/other/horizontal-scroll.tsx
+++ b/apps/web/components/project/epic/other/horizontal-scroll.tsx
@@ -21,9 +21,7 @@ export const HorizontalScroll: React.FC<{
     <div
       dir="ltr"
       style={{
-        margin: rtl
-          ? `0px ${taskListWidth}px 0px 0px`
-          : `0px 0px 0px ${taskListWidth}px`,
+        margin: '0px 0px 0px 510px',
       }}
       className={styles.scrollWrapper}
       onScroll={onScroll}

--- a/apps/web/helpers/date-helper.ts
+++ b/apps/web/helpers/date-helper.ts
@@ -245,11 +245,12 @@ export const getWeekNumberInMonth = (date: Date) => {
   const firstDayOfWeek = firstDayOfMonth.getDay()
   const dayOfMonth = date.getDate()
 
-  // 해당 월의 첫 번째 주의 시작일 계산
-  const firstWeekStart = firstDayOfWeek === 0 ? 1 : 8 - firstDayOfWeek
+  // 해당 월의 첫 번째 주의 시작일 계산 (일요일 기준)
+  const firstWeekStart = 1
 
   // 현재 날짜가 몇 번째 주인지 계산
   const weekNumber = Math.ceil((dayOfMonth - firstWeekStart + 1) / 7)
 
-  return `${weekNumber}`
+  // 항상 1 이상의 값을 반환
+  return `${Math.max(1, weekNumber)}`
 }

--- a/apps/web/helpers/date-helper.ts
+++ b/apps/web/helpers/date-helper.ts
@@ -197,13 +197,12 @@ export const getLocalDayOfWeek = (
   locale: string,
   format?: 'long' | 'short' | 'narrow' | undefined
 ) => {
-  let bottomValue = getCachedDateTimeFormat(locale, {
-    weekday: format,
+  // 영어 요일 표기를 위해 'en-US' 로케일 사용
+  let bottomValue = getCachedDateTimeFormat('en-US', {
+    weekday: 'short',
   }).format(date)
-  bottomValue = bottomValue.replace(
-    bottomValue[0],
-    bottomValue[0].toLocaleUpperCase()
-  )
+  // 대문자로 변환하고 첫 3글자만 사용
+  bottomValue = bottomValue.substring(0, 3).toUpperCase()
   return bottomValue
 }
 


### PR DESCRIPTION
## 🔗 Jira Ticket

- 관련 지라 티켓: [CM-166](https://starmix.atlassian.net/browse/CM-166)

## 📌 PR Type

- [X] ✨ Feature
- [X] 🐛 Bugfix
- [X] 🎨 Design

## 📝 작업 내용

- 에픽 페이지의 Day 뷰 날짜 표기 형식 변경
- Week 뷰 주 계산 방법 수정
- 간트 차트 수평 스크롤 활성화
- Sprint 뷰 활성화
- Sprint에 따른 에픽 클라이언트 사이드 필터링

## 📷 스크린샷

<img width="1123" alt="스크린샷 2025-06-08 오전 1 47 34" src="https://github.com/user-attachments/assets/caed6bcd-b7f8-4116-b348-20263835b30d" />