### PR TITLE
[CM-228] 회의록 제목 및 스크럼 마스터 수정 API 연동

### DIFF
--- a/apps/web/app/projects/[id]/(isActive)/meeting-notes/[meetingId]/MeetingNoteDetails.tsx
+++ b/apps/web/app/projects/[id]/(isActive)/meeting-notes/[meetingId]/MeetingNoteDetails.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Member } from '@cm/types/project'
+import { MeetingResponse } from '@cm/api/meetingNotes'
 import {
   Popover,
   PopoverContent,
@@ -15,8 +16,8 @@ interface MeetingNoteDetailsProps {
   createdAt: Date
   updatedAt: Date
   members: Member[]
-  initialScrumMaster: Member
-  onScrumMasterChange: (member: Member) => void
+  initialScrumMaster: MeetingResponse['master']
+  onScrumMasterChange: (memberId: string) => void
 }
 
 export function MeetingNoteDetails({
@@ -28,12 +29,18 @@ export function MeetingNoteDetails({
 }: MeetingNoteDetailsProps) {
   const [isScrumMasterOpen, setIsScrumMasterOpen] = useState(false)
   const [selectedScrumMaster, setSelectedScrumMaster] =
-    useState<Member>(initialScrumMaster)
+    useState<MeetingResponse['master']>(initialScrumMaster)
 
   const handleScrumMasterChange = (member: Member) => {
-    setSelectedScrumMaster(member)
+    setSelectedScrumMaster({
+      userId: member.userId,
+      name: member.name,
+      email: member.email,
+      profileImageUrl: member.profileImageUrl,
+      profiles: [member.profile]
+    })
     setIsScrumMasterOpen(false)
-    onScrumMasterChange(member)
+    onScrumMasterChange(member.userId)
   }
 
   return (

--- a/apps/web/app/projects/[id]/(isActive)/meeting-notes/[meetingId]/page.tsx
+++ b/apps/web/app/projects/[id]/(isActive)/meeting-notes/[meetingId]/page.tsx
@@ -1,10 +1,14 @@
 'use client'
 
-import { MeetingResponse, getMeeting, getRoomDetails, updateMeeting } from '@cm/api/meetingNotes'
-import { Member } from '@cm/types/project'
 import { useAuthStore } from '@/stores/useAuthStore'
+import {
+  MeetingResponse,
+  getMeeting,
+  getRoomDetails,
+  updateMeeting,
+} from '@cm/api/meetingNotes'
+import { Member } from '@cm/types/project'
 import { Button } from '@cm/ui/components/ui/button'
-import { Input } from '@cm/ui/components/ui/input'
 import {
   Dialog,
   DialogContent,
@@ -13,8 +17,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@cm/ui/components/ui/dialog'
-import { useParams, useRouter } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { Input } from '@cm/ui/components/ui/input'
 import {
   Tooltip,
   TooltipContent,
@@ -22,6 +25,9 @@ import {
   TooltipTrigger,
 } from '@cm/ui/components/ui/tooltip'
 import { Sparkles } from 'lucide-react'
+import { useParams, useRouter } from 'next/navigation'
+import { useEffect, useState } from 'react'
+import ReactMarkdown from 'react-markdown'
 
 import { Editor } from './Editor'
 import { MeetingNoteDetails } from './MeetingNoteDetails'
@@ -43,11 +49,11 @@ export default function MeetingNotePage() {
       name: '',
       email: '',
       profileImageUrl: '',
-      profiles: []
+      profiles: [],
     },
     projectId: '',
     timestamp: new Date().toISOString(),
-    summary: ''
+    summary: '',
   })
   const [members, setMembers] = useState<Member[]>([])
   const [roomInfo, setRoomInfo] = useState<{
@@ -186,19 +192,34 @@ export default function MeetingNotePage() {
               readOnly={!isEditingTitle}
             />
             <div className="flex items-center gap-2">
-              <Button
-                variant="cmoutline"
-                onClick={() => setShowSummaryDialog(true)}
-                disabled={!meetingInfo.summary?.trim()}
-              >
-                요약본 확인
-              </Button>
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div>
+                      <Button
+                        variant="cmoutline"
+                        onClick={() => setShowSummaryDialog(true)}
+                        disabled={!meetingInfo.summary?.trim()}
+                      >
+                        요약본 확인
+                      </Button>
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {!meetingInfo.summary?.trim() ? (
+                      <p>AI 요약을 먼저 진행해주세요.</p>
+                    ) : (
+                      <p>AI가 생성한 회의록 요약본을 확인합니다.</p>
+                    )}
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
               <TooltipProvider>
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button variant="cm" onClick={handleComplete}>
                       <Sparkles className="w-4 h-4" />
-                      완료
+                      AI 요약 시작
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent>
@@ -238,41 +259,46 @@ export default function MeetingNotePage() {
       <Dialog open={showCompleteDialog} onOpenChange={setShowCompleteDialog}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>회의록 완료</DialogTitle>
+            <DialogTitle>AI 요약 시작</DialogTitle>
             <DialogDescription>
-              회의록을 완료하고 요약 및 액션 아이템 추출을 진행하시겠습니까?
+              AI를 통해 회의록을 요약하고 액션 아이템을 추출하시겠습니까?
               <br />
               완료 후에는 회의록을 수정할 수 없습니다.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
             <Button
-              variant="outline"
+              variant="cmoutline"
               onClick={() => setShowCompleteDialog(false)}
             >
               취소
             </Button>
             <Button variant="cm" onClick={handleConfirmComplete}>
-              확인
+              <Sparkles className="w-4 h-4 mr-2" />
+              AI 요약 시작
             </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
 
       <Dialog open={showSummaryDialog} onOpenChange={setShowSummaryDialog}>
-        <DialogContent>
+        <DialogContent className="max-w-3xl max-h-[80vh]">
           <DialogHeader>
             <DialogTitle>회의록 요약</DialogTitle>
             <DialogDescription>
               AI가 생성한 회의록 요약본입니다.
             </DialogDescription>
           </DialogHeader>
-          <div className="mt-4 p-4 bg-gray-50 rounded-lg">
-            <p className="whitespace-pre-wrap">{meetingInfo.summary}</p>
+          <div className="mt-4 p-4 bg-muted/50 rounded-lg overflow-y-auto max-h-[calc(80vh-200px)] prose prose-sm max-w-none">
+            {meetingInfo.summary ? (
+              <ReactMarkdown>{meetingInfo.summary}</ReactMarkdown>
+            ) : (
+              <p className="text-gray-500">요약본이 없습니다.</p>
+            )}
           </div>
           <DialogFooter>
             <Button
-              variant="outline"
+              variant="cmoutline"
               onClick={() => setShowSummaryDialog(false)}
             >
               닫기

--- a/apps/web/components/project/meeting-notes/MeetingNotesList.tsx
+++ b/apps/web/components/project/meeting-notes/MeetingNotesList.tsx
@@ -22,11 +22,7 @@ export default function MeetingNotesList({
   const router = useRouter()
 
   const handleRowClick = (meeting: Meeting) => {
-    router.push(
-      `/projects/${projectId}/meeting-notes/${meeting.meetingId}?title=${encodeURIComponent(
-        meeting.title
-      )}&roomId=${meeting.meetingId}`
-    )
+    router.push(`/projects/${projectId}/meeting-notes/${meeting.meetingId}`)
   }
 
   return (

--- a/apps/web/components/project/meeting-notes/MeetingWizard.tsx
+++ b/apps/web/components/project/meeting-notes/MeetingWizard.tsx
@@ -186,7 +186,6 @@ export default function MeetingWizard() {
     },
   })
 
-  // SSE 연결 초기화 및 관리
   const initializeSSE = useCallback(async () => {
     if (
       !meetingId ||
@@ -202,11 +201,9 @@ export default function MeetingWizard() {
       setLoading(true)
       setIsInitialized(true)
 
-      // 회의록 내용 전송
       const meetingData = await getMeeting(user.accessToken, meetingId)
       setOriginalContent(meetingContent)
 
-      // SSE 연결 생성
       const newEventSource = startSSE()
       if (!newEventSource) {
         throw new Error('SSE 연결에 실패했습니다.')
@@ -214,7 +211,6 @@ export default function MeetingWizard() {
 
       newEventSource.onopen = () => {
         console.log('SSE 연결 성공')
-        // SSE 연결이 성공한 후에 회의록 내용 전송
         sendMeetingContent(user.accessToken, {
           meetingId,
           title: meetingData.title,
@@ -270,7 +266,6 @@ export default function MeetingWizard() {
     }
   }, [])
 
-  // SSE 재연결 시도
   useEffect(() => {
     if (!eventSource && isInitialized && step === 0) {
       console.log('SSE 재연결 시도')
@@ -485,6 +480,7 @@ export default function MeetingWizard() {
                 addButtonText="+ 액션 아이템 추가"
                 defaultRow={DEFAULT_ACTION_ITEM}
                 showHeader={false}
+                canAddRow={false}
                 meta={{
                   updateData: (
                     rowIndex: number,

--- a/packages/api/src/meetingNotes.ts
+++ b/packages/api/src/meetingNotes.ts
@@ -15,7 +15,7 @@ interface LiveblocksRoom {
   usersAccesses: Record<string, string[]>
 }
 
-interface MeetingResponse {
+export interface MeetingResponse {
   meetingId: string
   title: string
   content: string
@@ -96,6 +96,11 @@ interface Task {
 
 interface UpdateActionItemsRequest {
   tasks: Task[]
+}
+
+interface UpdateMeetingRequest {
+  title: string
+  masterId: string
 }
 
 export const getMeetings = async (
@@ -302,6 +307,37 @@ export const updateActionItems = async (
     }
   } catch (error) {
     console.error('액션 아이템 업데이트 에러:', error)
+    throw error
+  }
+}
+
+export const updateMeeting = async (
+  accessToken: string,
+  meetingId: string,
+  data: UpdateMeetingRequest
+): Promise<void> => {
+  if (!accessToken) {
+    throw new Error('인증 토큰이 없습니다.')
+  }
+
+  try {
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/meeting/${meetingId}`,
+      {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify(data),
+      }
+    )
+
+    if (!response.ok) {
+      throw new Error(`회의 정보 업데이트 실패: ${response.status}`)
+    }
+  } catch (error) {
+    console.error('회의 정보 업데이트 에러:', error)
     throw error
   }
 }


### PR DESCRIPTION
## 🔗 Jira Ticket

- 관련 지라 티켓: [CM-228](https://starmix.atlassian.net/browse/CM-228)

## 📌 PR Type
- [X] ✨ Feature

## 📝 작업 내용

- 회의록 제목 및 스크럼 마스터 수정 API 연동
- 회의록 요약본 확인 모달 추가
- 회의록 액션 아이템 추출 시 아이템 추가 기능 삭제

## 📷 스크린샷
![image](https://github.com/user-attachments/assets/06e23805-cbdf-4338-89c6-0695d16431a7)

